### PR TITLE
It seems like Alfresco have between versions have made a change in th…

### DIFF
--- a/fme-alfresco-extdl-share/src/main/resources/alfresco/web-extension/fme-extended-datalist-config-custom.xml
+++ b/fme-alfresco-extdl-share/src/main/resources/alfresco/web-extension/fme-extended-datalist-config-custom.xml
@@ -155,7 +155,7 @@
                <show id="cm:creator" />
                <show id="cm:created" />
                <show id="fm:discussable"/>
-               <show id="cm:versionable"/>
+               <show id="cm:versionLabel"/>
             </field-visibility>
             <edit-form template="../data-lists/forms/dataitem-edit.ftl" />
             <view-form template="../data-lists/forms/dataitem-view.ftl" />
@@ -188,7 +188,7 @@
                   	<control-param name="style">width:450px;</control-param>
                   </control>
                </field>
-               <field id="cm:versionable" label-id="form.label.version-history" set="normal">
+               <field id="cm:versionLabel" label-id="form.label.version-history" set="normal">
                   <control template="/org/alfresco/components/form/controls/version.ftl" />
                </field>
             </appearance>
@@ -362,7 +362,7 @@
                <show id="cm:creator" />
                <show id="cm:created" />
                <show id="fm:discussable"/>
-               <show id="cm:versionable"/>
+               <show id="cm:versionLabel"/>
             </field-visibility>
             <edit-form template="../data-lists/forms/dataitem-edit.ftl" />
             <view-form template="../data-lists/forms/dataitem-view.ftl" />
@@ -421,7 +421,7 @@
                       <control-param name="style">width:450px;</control-param>
                   </control>
                </field>
-               <field id="cm:versionable" label-id="form.label.version-history" set="normal">
+               <field id="cm:versionLabel" label-id="form.label.version-history" set="normal">
                   <control template="/org/alfresco/components/form/controls/version.ftl" />
                </field>	
             </appearance>
@@ -595,7 +595,7 @@
                <show id="cm:creator" />
                <show id="cm:created" />
                <show id="fm:discussable"/>
-               <show id="cm:versionable"/>
+               <show id="cm:versionLabel"/>
             </field-visibility>
              <edit-form template="../data-lists/forms/dataitem-edit.ftl" />
             <view-form template="../data-lists/forms/dataitem-view.ftl" />
@@ -653,7 +653,7 @@
                       <control-param name="style">width:450px;</control-param>
                   </control>
                </field>
-               <field id="cm:versionable" label-id="form.label.version-history" set="normal">
+               <field id="cm:versionLabel" label-id="form.label.version-history" set="normal">
                   <control template="/org/alfresco/components/form/controls/version.ftl" />
                </field>	
             </appearance>
@@ -822,7 +822,7 @@
                <show id="fm:discussable"/>
                <show id="cm:creator" />
                <show id="cm:created" />
-               <show id="cm:versionable"/>
+               <show id="cm:versionLabel"/>
             </field-visibility>
             <edit-form template="../data-lists/forms/dataitem-edit.ftl" />
             <view-form template="../data-lists/forms/dataitem-view.ftl" />
@@ -869,7 +869,7 @@
                		<control template="/org/alfresco/components/form/controls/extended-person.ftl"/>
                	</field>
                <field id="cm:created" set="other"/>
-               <field id="cm:versionable" label-id="form.label.version-history" set="other">
+               <field id="cm:versionLabel" label-id="form.label.version-history" set="other">
                   <control template="/org/alfresco/components/form/controls/version.ftl" />
                </field>	
             </appearance>
@@ -1044,7 +1044,7 @@
                <show id="fm:discussable"/>
                <show id="cm:creator" />
                <show id="cm:created" />
-               <show id="cm:versionable"/>
+               <show id="cm:versionLabel"/>
             </field-visibility>
             <edit-form template="../data-lists/forms/dataitem-edit.ftl" />
             <view-form template="../data-lists/forms/dataitem-view.ftl" />
@@ -1088,7 +1088,7 @@
                		<control template="/org/alfresco/components/form/controls/extended-person.ftl"/>
                	</field>
                <field id="cm:created" set="other"/>
-               <field id="cm:versionable" label-id="form.label.version-history" set="other">
+               <field id="cm:versionLabel" label-id="form.label.version-history" set="other">
                   <control template="/org/alfresco/components/form/controls/version.ftl" />
                </field>	
             </appearance>
@@ -1282,7 +1282,7 @@
                <show id="fm:discussable"/>
                <show id="cm:creator" />
                <show id="cm:created" />
-               <show id="cm:versionable"/>
+               <show id="cm:versionLabel"/>
             </field-visibility>
             <edit-form template="../data-lists/forms/dataitem-edit.ftl" />
             <view-form template="../data-lists/forms/dataitem-view.ftl" />
@@ -1346,7 +1346,7 @@
                		<control template="/org/alfresco/components/form/controls/extended-person.ftl"/>
                	</field>
                <field id="cm:created" set="other"/>
-               <field id="cm:versionable" label-id="form.label.version-history" set="other">
+               <field id="cm:versionLabel" label-id="form.label.version-history" set="other">
                   <control template="/org/alfresco/components/form/controls/version.ftl" />
                </field>	
             </appearance>
@@ -1498,7 +1498,7 @@
                <show id="fm:discussable"/>
                <show id="cm:creator" />
                <show id="cm:created" />
-               <show id="cm:versionable"/>
+               <show id="cm:versionLabel"/>
             </field-visibility>
             <edit-form template="../data-lists/forms/dataitem-edit.ftl" />
             <view-form template="../data-lists/forms/dataitem-view.ftl" />
@@ -1547,7 +1547,7 @@
                		<control template="/org/alfresco/components/form/controls/extended-person.ftl"/>
                	</field>
                <field id="cm:created" set="other"/>
-               <field id="cm:versionable" label-id="form.label.version-history" set="other">
+               <field id="cm:versionLabel" label-id="form.label.version-history" set="other">
                   <control template="/org/alfresco/components/form/controls/version.ftl" />
                </field>	
             </appearance>
@@ -1733,7 +1733,7 @@
                <show id="fm:discussable"/>
                <show id="cm:creator" />
                <show id="cm:created" />
-               <show id="cm:versionable"/>
+               <show id="cm:versionLabel"/>
             </field-visibility>
             <edit-form template="../data-lists/forms/dataitem-edit.ftl" />
             <view-form template="../data-lists/forms/dataitem-view.ftl" />
@@ -1776,7 +1776,7 @@
                		<control template="/org/alfresco/components/form/controls/extended-person.ftl"/>
                	</field>
                <field id="cm:created" set="other"/>
-               <field id="cm:versionable" label-id="form.label.version-history" set="other">
+               <field id="cm:versionLabel" label-id="form.label.version-history" set="other">
                   <control template="/org/alfresco/components/form/controls/version.ftl" />
                </field>	
             </appearance>
@@ -1914,7 +1914,7 @@
                <show id="fm:discussable"/>
                <show id="cm:creator" />
                <show id="cm:created" />
-               <show id="cm:versionable"/>
+               <show id="cm:versionLabel"/>
             </field-visibility>
             <edit-form template="../data-lists/forms/dataitem-edit.ftl" />
             <view-form template="../data-lists/forms/dataitem-view.ftl" />
@@ -1951,7 +1951,7 @@
                		<control template="/org/alfresco/components/form/controls/extended-person.ftl"/>
                	</field>
                <field id="cm:created" set="other"/>
-               <field id="cm:versionable" label-id="form.label.version-history" set="other">
+               <field id="cm:versionLabel" label-id="form.label.version-history" set="other">
                   <control template="/org/alfresco/components/form/controls/version.ftl" />
                </field>	
             </appearance>

--- a/fme-alfresco-extdl-share/src/main/resources/alfresco/web-extension/site-webscripts/org/alfresco/components/form/controls/version.ftl
+++ b/fme-alfresco-extdl-share/src/main/resources/alfresco/web-extension/site-webscripts/org/alfresco/components/form/controls/version.ftl
@@ -1,6 +1,3 @@
-<#if (context.properties.nodeRef?? && context.properties.nodeRef?js_string?starts_with("workspace://SpacesStore")) 
-|| ((form.mode == "edit" || form.mode == "view") && args.itemId?? && args.itemId?js_string?starts_with("workspace://SpacesStore"))>
-
 <#assign controlId = fieldHtmlId + "-cntrl">
 
 <div class="form-field">
@@ -30,4 +27,3 @@
    </div>
    
 </div>
-</#if>


### PR DESCRIPTION
…e forms engine.

When configuring the versionable functionality for datalist items, fme have used the aspect name in the show-property xml element. Since cm:versionable is not a property name Alfresco in latter versions wont output the contents of the version.ftl form template. Instead I have changed the configuration to use the existing property cm:versionLabel. I also made a change in the template and removed a conditional statement at the top that prevented the form field from rendering. Fixes #24